### PR TITLE
Behave like Mocha core reporters

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,20 @@
+var reporters = require('mocha').reporters;
+
+/**
+ * Mocha reporter for Mugshot visual regression testing lib
+ *
+ * @param runner - Mocha's runner
+ * @param {Object} options - Options object received from Mocha
+ */
+function MugshotReporter(runner, options) {
+  var reporter = options.reporterOptions.reporter,
+      CLIReporter = reporters[reporter];
+
+  if (CLIReporter === undefined) {
+    CLIReporter = reporters.Spec;
+  }
+
+  new CLIReporter(runner);
+};
+
+module.exports = MugshotReporter;

--- a/index.js
+++ b/index.js
@@ -7,8 +7,13 @@ var reporters = require('mocha').reporters;
  * @param {Object} options - Options object received from Mocha
  */
 function MugshotReporter(runner, options) {
-  var reporter = options.reporterOptions.reporter,
-      CLIReporter = reporters[reporter];
+  var reporter, CLIReporter;
+
+  if (options.reporterOptions !== undefined) {
+    reporter = options.reporterOptions.reporter;
+  }
+
+  CLIReporter = reporters[reporter];
 
   if (CLIReporter === undefined) {
     CLIReporter = reporters.Spec;

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var reporters = require('mocha').reporters;
 /**
  * Mocha reporter for Mugshot visual regression testing lib
  *
- * @param runner - Mocha's runner
+ * @param {Mocha.Runner} runner - Mocha's runner
  * @param {Object} options - Options object received from Mocha
  */
 function MugshotReporter(runner, options) {

--- a/package.json
+++ b/package.json
@@ -20,5 +20,9 @@
   "bugs": {
     "url": "https://github.com/uberVU/mocha-mugshot-reporter/issues"
   },
-  "homepage": "https://github.com/uberVU/mocha-mugshot-reporter#readme"
+  "homepage": "https://github.com/uberVU/mocha-mugshot-reporter#readme",
+  "devDependencies": {
+    "chai": "^3.2.0",
+    "mocha": "^2.3.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "mocha-mugshot-reporter",
+  "version": "0.0.0",
+  "description": "Mocha reporter for the Mugshot visual regression testing lib",
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/uberVU/mocha-mugshot-reporter.git"
+  },
+  "keywords": [
+    "mocha",
+    "mugshot",
+    "reporter"
+  ],
+  "author": "Simion Florentin",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/uberVU/mocha-mugshot-reporter/issues"
+  },
+  "homepage": "https://github.com/uberVU/mocha-mugshot-reporter#readme"
+}

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "mocha": "^2.3.1"
+  },
+  "peerDependencies": {
+    "mocha": "^2.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Mocha reporter for the Mugshot visual regression testing lib",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha test/unit",
+    "test-integration": "mocha test/integration"
   },
   "repository": {
     "type": "git",

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -1,0 +1,67 @@
+var expect = require('chai').expect,
+    exec = require('child_process').exec,
+    path = require('path');
+
+var testFixturePath = path.join(__dirname, '../test-fixture.js'),
+    mugshotReporter = path.join(__dirname, '../../index.js');
+
+/**
+ * Captures the output of the reporters, i.e Mocha's reporters and our reporter
+ *
+ * @param {String} reporter - The name of the wanted reporter to test
+ * @param {getOutputsCb} done - Called after all operations have finished
+ */
+function getOutputs(reporter, done) {
+  var command = 'mocha ' + testFixturePath + ' --reporter=';
+
+  exec(command + reporter, function(error, mochaReporterOutput) {
+    if (error) {
+      return done(error);
+    }
+
+    exec(command + mugshotReporter + ' --reporter-options reporter=' + reporter,
+       function(error, mugshotReporterOutput) {
+      if (error) {
+        return done(error);
+      }
+
+      done(null, mochaReporterOutput, mugshotReporterOutput);
+    });
+  });
+}
+
+/**
+ * @callback getOutputsCb
+ * @param error
+ * @param {String} mochaReporterOutput
+ * @param {String} mugshotReporterOutput
+ */
+
+describe('Mocha-Mugshot CLI reporting', function() {
+  var reporters = ['', 'spec', 'dot'];
+
+  reporters.forEach(function(reporter) {
+    it('should output the same with Mocha ' + ((reporter === '') ? 'default' :
+       reporter) + ' reporter', function(done) {
+      getOutputs(reporter, function(error, mochaReporterOutput,
+         mugshotReporterOutput) {
+        if (error) {
+          throw error;
+        }
+
+        // slice out the time
+        expected = mochaReporterOutput.slice(0,
+          (mochaReporterOutput.search('passing') - 1));
+
+        result = mugshotReporterOutput.slice(0,
+          (mugshotReporterOutput.search('passing') - 1));
+
+        expect(expected).to.be.deep.equal(result);
+
+        done();
+      });
+    });
+  });
+});
+
+

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -56,8 +56,9 @@ describe('Mocha-Mugshot CLI reporting', function() {
          mugshotReporterOutput) {
 
         // Delete the time, because it is variable.
-        var mochaOutput  = mochaReporterOutput.replace(/\([0-9]+ms\)/i, '');
-        var mugshotOutput  = mugshotReporterOutput.replace(/\([0-9]+ms\)/i, '');
+        var regex = /\([0-9]+ms\)/i,
+            mochaOutput  = mochaReporterOutput.replace(regex, ''),
+            mugshotOutput  = mugshotReporterOutput.replace(regex, '');
 
         expect(mugshotOutput).to.be.equal(mochaOutput);
 

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -48,9 +48,9 @@ describe('Mocha-Mugshot CLI reporting', function() {
   var reporters = ['', 'spec', 'dot'];
 
   reporters.forEach(function(reporter) {
-    var description =  (reporter === '') ? 'default' : reporter;
+    var reporterName = reporter === '' ? 'default' : reporter;
 
-    it('should output the same with Mocha ' + description + ' reporter',
+    it('should output the same with Mocha ' + reporterName + ' reporter',
        function(done) {
       getOutputs(reporter, function(mochaReporterOutput,
          mugshotReporterOutput) {

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -48,8 +48,10 @@ describe('Mocha-Mugshot CLI reporting', function() {
   var reporters = ['', 'spec', 'dot'];
 
   reporters.forEach(function(reporter) {
-    it('should output the same with Mocha ' + ((reporter === '') ? 'default' :
-       reporter) + ' reporter', function(done) {
+    var description =  (reporter === '') ? 'default' : reporter;
+
+    it('should output the same with Mocha ' + description + ' reporter',
+       function(done) {
       getOutputs(reporter, function(mochaReporterOutput,
          mugshotReporterOutput) {
 

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -55,7 +55,7 @@ describe('Mocha-Mugshot CLI reporting', function() {
       getOutputs(reporter, function(mochaReporterOutput,
          mugshotReporterOutput) {
 
-        // delete the time (is variable)
+        // Delete the time, because it is variable.
         var mochaOutput  = mochaReporterOutput.replace(/\([0-9]+ms\)/i, '');
         var mugshotOutput  = mugshotReporterOutput.replace(/\([0-9]+ms\)/i, '');
 

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -1,6 +1,6 @@
 var expect = require('chai').expect,
     Mocha = require('mocha'),
-    path = require('path')
+    path = require('path');
 
 var testFixturePath = path.join(__dirname, '../test-fixture.js'),
     mugshotReporter = path.join(__dirname, '../../index.js');

--- a/test/test-fixture.js
+++ b/test/test-fixture.js
@@ -17,6 +17,7 @@ describe('Suite 1', function() {
   });
 
   it('Test 2 in Suite 1', function() {
+    throw new Error('error');
   });
 });
 

--- a/test/test-fixture.js
+++ b/test/test-fixture.js
@@ -1,17 +1,8 @@
 describe('Suite 1', function() {
-  before(function() {
-  });
-
-  beforeEach(function() {
-  });
-
   it('Test 1 in Suite 1', function() {
   });
 
   describe('Suite 1.1', function() {
-    before(function() {
-    });
-
     it('Test 1 in Suite 1.1', function() {
     });
   });

--- a/test/test-fixture.js
+++ b/test/test-fixture.js
@@ -1,0 +1,26 @@
+describe('Suite 1', function() {
+  before(function() {
+  });
+
+  beforeEach(function() {
+  });
+
+  it('Test 1 in Suite 1', function() {
+  });
+
+  describe('Suite 1.1', function() {
+    before(function() {
+    });
+
+    it('Test 1 in Suite 1.1', function() {
+    });
+  });
+
+  it('Test 2 in Suite 1', function() {
+  });
+});
+
+describe('Suite 2', function() {
+  it('Test 1 in Suite 2', function() {
+  });
+});


### PR DESCRIPTION
## Need

```
As a developer
I need to have a report to present it to my users
So that they will know what happens with their tests
```

## Deliverables

Our reporter would behave like the required reporter. If no reporter is required, it would act like the [Spec](https://github.com/mochajs/mocha/blob/master/lib/reporters/spec.js) reporter (default).

## Solution

The solution is to have `Mocha` as a dependency and require Mocha's reporters and instantiate the required reporter.

```js
var reporters = require('mocha').reporters;

// runner is passed by mocha to our reporter
new reporters.Spec(runner);
```

The `default` can be changed by passing through mocha [reporter-options](https://mochajs.org/#usage), a key=value pair, which will be key: `reporter` and the value will be any `mocha core reporter`.

```bash
mocha file --reporter ourReporter --reporter-options reporter=nyan
```

~~For testing, we should use [exec](http://devdocs.io/node/child_process#child_process_child_process_exec_command_options_callback) from the `child_process`,  like this:~~

```js
function getOutputs(reporter, done) {
  // simple mocha
  exec('mocha ' + file + ' --reporter=' + reporter, function(error, output, stderr) {
    // mocha with our reporter
    exec('mocha ' + file + ' --reporter=myReporter' + '--reporter-option reporter=' + reporter,
      function(error, myOutput, stderr) {
        done(output, myOutput);
      });
  });
}
```

**The above solution is not good.**

We will use Mocha [programtically](https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically), also to capture the output and assert to be equal, by calling mocha two times like in the above snippet.

To do the assertion we must remove the time from the ouput (test duration), because it is variable.

And to do the assertions:

```js
describe('description', function() {
  // we will store the reporters here
  var reporters = [] ;

  reporters.forEach(function(reporter) {
    it('should output the same with ' + reporter + ' reporter', function(done) {
      getOutputs(reporter, function(output, myOutput) {
        expect(output).to.be.deep.equal(myOutput);
      
        done();
      });
    });
  });
});
```
