### PR TITLE
Refactor data generation

### DIFF
--- a/lib/data-generator.js
+++ b/lib/data-generator.js
@@ -18,7 +18,12 @@ module.exports = function(runner, done) {
   });
 
   runner.on('test end', function(test) {
-    suites[suites.length - 1].tests.push(test);
+    suites[suites.length - 1].tests.push({
+      title: test.title,
+      state: test.state,
+      result: test.ctx.result,
+      error: test.err
+    });
   });
 
   runner.on('suite end', function() {

--- a/test/unit/data-generator.js
+++ b/test/unit/data-generator.js
@@ -98,7 +98,7 @@ describe('Data generator', function() {
       var tests = generateTests(randomNumber, 'passed'),
           expected = [objectAssign({}, output.rootSuite, {tests: tests})];
 
-      expect(data).to.be.deep.equal(expected);
+      expect(data.length).to.be.equal(expected.length);
 
       done();
     });
@@ -120,7 +120,7 @@ describe('Data generator', function() {
       var tests = generateTests(randomNumber, 'failed'),
           expected = [objectAssign({}, output.rootSuite, {tests: tests})];
 
-      expect(data).to.be.deep.equal(expected);
+      expect(data.length).to.be.deep.equal(expected.length);
 
       done();
     });
@@ -141,7 +141,7 @@ describe('Data generator', function() {
     generate(runner, function(data) {
       var expected = generateSuites(randomNumber, 'global');
 
-      expect(data).to.be.deep.equal(expected);
+      expect(data.length).to.be.deep.equal(expected.length);
 
       done();
     });
@@ -196,27 +196,37 @@ describe('Data generator', function() {
       for (var i = 0; i <= n; i++) {
         expected[i].tests = generateTests(randomNumbers[i], 'passed');
 
-        // The id is not a real filed we're adding it only for this test.
+        // We are adding in the title an id only for testing purposes.
         for (var j = 0; j < expected[i].tests.length; j++) {
-          expected[i].tests[j]._id = j;
+          expected[i].tests[j].title += j;
         }
       }
 
-      expect(data).to.be.deep.equal(expected);
+      for (var i = 0; i <= n; i++) {
+        for (var j = 0; j < randomNumbers[i]; j++) {
+          expect(data[i].tests[j].title).to.be.equal(expected[i].tests[j].title);
+        }
+      }
 
       done();
     });
 
     runner.emit('suite', input.rootSuite);
     for (var i = 0; i < randomNumbers[0]; i++) {
-      runner.emit('test end', objectAssign({}, input.passTest, {_id: i}));
+      var test = objectAssign({}, input.passTest);
+
+      test.title += i;
+      runner.emit('test end', test);
     }
 
     for (var i = 1; i <= n; i++) {
       runner.emit('suite', input.suite);
 
       for (var j = 0; j < randomNumbers[i]; j++) {
-        runner.emit('test end', objectAssign({}, input.passTest, {_id: j}));
+        var test = objectAssign({}, input.passTest);
+
+        test.title += j;
+        runner.emit('test end', test);
       }
 
       runner.emit('suite end');

--- a/test/unit/data-generator.js
+++ b/test/unit/data-generator.js
@@ -101,7 +101,7 @@ describe('Data generator', function() {
       var tests = generateTests(randomNumber, 'passed'),
           expected = [objectAssign({}, output.rootSuite, {tests: tests})];
 
-      expect(data.length).to.be.equal(expected.length);
+      expect(data).to.have.length(expected.length);
 
       done();
     });
@@ -123,7 +123,7 @@ describe('Data generator', function() {
       var tests = generateTests(randomNumber, 'failed'),
           expected = [objectAssign({}, output.rootSuite, {tests: tests})];
 
-      expect(data.length).to.be.deep.equal(expected.length);
+      expect(data).to.have.length(expected.length);
 
       done();
     });
@@ -144,7 +144,7 @@ describe('Data generator', function() {
     generate(runner, function(data) {
       var expected = generateSuites(randomNumber, 'global');
 
-      expect(data.length).to.be.deep.equal(expected.length);
+      expect(data).to.have.length(expected.length);
 
       done();
     });

--- a/test/unit/data-generator.js
+++ b/test/unit/data-generator.js
@@ -73,7 +73,10 @@ function generateTests(n, type) {
 }
 
 describe('Data generator', function() {
-  var runner;
+  var suiteProps = ['title', 'indent', 'tests'],
+      passTestProps = ['title', 'state'],
+      failTestProps = ['title', 'state', 'error'],
+      runner;
 
   beforeEach(function() {
     runner = new EventEmitter();
@@ -125,7 +128,7 @@ describe('Data generator', function() {
       done();
     });
 
-    runner.emit('suite',input.rootSuite);
+    runner.emit('suite', input.rootSuite);
 
     for (var i = 0; i < randomNumber; i++) {
       runner.emit('test end', input.failTest);
@@ -155,6 +158,50 @@ describe('Data generator', function() {
 
     runner.emit('suite end', input.rootSuite);
     runner.emit('end');
+  });
+
+  suiteProps.forEach(function(prop) {
+    it('should contain the Suite "' + prop + '" property', function(done) {
+      generate(runner, function(data) {
+        expect(data[0][prop]).to.deep.equal(output.rootSuite[prop]);
+
+         done();
+      });
+
+      runner.emit('suite', input.rootSuite);
+      runner.emit('suite end', input.rootSuite);
+      runner.emit('end');
+    });
+  });
+
+  passTestProps.forEach(function(prop) {
+    it('should contain the pass Test "' + prop + '" property', function(done) {
+      generate(runner, function(data) {
+        expect(data[0].tests[0][prop]).to.be.deep.equal(output.passTest[prop]);
+
+        done();
+      });
+
+      runner.emit('suite', input.rootSuite);
+      runner.emit('test end', input.passTest);
+      runner.emit('suite end', input.rootSuite);
+      runner.emit('end');
+    });
+  });
+
+  failTestProps.forEach(function(prop) {
+    it('should contain the fail Test "' + prop + '" property', function(done) {
+      generate(runner, function(data) {
+        expect(data[0].tests[0][prop]).to.be.deep.equal(output.failTest[prop]);
+
+        done();
+      });
+
+      runner.emit('suite', input.rootSuite);
+      runner.emit('test end', input.failTest);
+      runner.emit('suite end', input.rootSuite);
+      runner.emit('end');
+    });
   });
 
   it('should indent nested suites properly', function(done) {

--- a/test/unit/data-generator.js
+++ b/test/unit/data-generator.js
@@ -74,8 +74,8 @@ function generateTests(n, type) {
 
 describe('Data generator', function() {
   var suiteProps = ['title', 'indent', 'tests'],
-      passTestProps = ['title', 'state'],
-      failTestProps = ['title', 'state', 'error'],
+      passTestProps = ['title', 'state', 'result'],
+      failTestProps = ['title', 'state', 'result', 'error'],
       runner;
 
   beforeEach(function() {

--- a/test/unit/data-generator.js
+++ b/test/unit/data-generator.js
@@ -91,27 +91,6 @@ describe('Data generator', function() {
     runner.emit('end');
   });
 
-  it('should contain all props from Mocha\'s test object', function(done) {
-    var test = {
-      a: 'a',
-      b: 'b',
-      number: 7
-    };
-
-    generate(runner, function(data) {
-      var expected = [objectAssign({}, output.rootSuite, {tests: [test]})];
-
-      expect(data).to.be.deep.equal(expected);
-
-      done();
-    });
-
-    runner.emit('suite', input.rootSuite);
-    runner.emit('test end', test);
-    runner.emit('suite end', input.rootSuite);
-    runner.emit('end');
-  });
-
   it('should generate a Test for each of Mocha\'s passed it', function(done) {
     var randomNumber = getRandomNumber();
 

--- a/test/unit/data-generator.js
+++ b/test/unit/data-generator.js
@@ -165,7 +165,7 @@ describe('Data generator', function() {
       generate(runner, function(data) {
         expect(data[0][prop]).to.deep.equal(output.rootSuite[prop]);
 
-         done();
+        done();
       });
 
       runner.emit('suite', input.rootSuite);
@@ -251,7 +251,8 @@ describe('Data generator', function() {
 
       for (var i = 0; i <= n; i++) {
         for (var j = 0; j < randomNumbers[i]; j++) {
-          expect(data[i].tests[j].title).to.be.equal(expected[i].tests[j].title);
+          expect(data[i].tests[j].title).to.be
+            .equal(expected[i].tests[j].title);
         }
       }
 

--- a/test/unit/data/input.js
+++ b/test/unit/data/input.js
@@ -7,11 +7,21 @@ module.exports = {
   },
   passTest: {
     title: 'test',
-    state: 'passed'
+    state: 'passed',
+    ctx: {
+      result: {
+        isEqual: true
+      }
+    }
   },
   failTest: {
     title: 'test',
     state: 'failed',
+    ctx: {
+      result: {
+        isEqual: false
+      }
+    },
     err: new Error('big error')
   }
 };

--- a/test/unit/data/output.js
+++ b/test/unit/data/output.js
@@ -16,6 +16,6 @@ module.exports = {
   failTest: {
     title: 'test',
     state: 'failed',
-    err: new Error('big error')
+    error: new Error('big error')
   }
 };

--- a/test/unit/data/output.js
+++ b/test/unit/data/output.js
@@ -11,11 +11,17 @@ module.exports = {
   },
   passTest: {
     title: 'test',
-    state: 'passed'
+    state: 'passed',
+    result: {
+      isEqual: true
+    }
   },
   failTest: {
     title: 'test',
     state: 'failed',
+    result: {
+      isEqual: false
+    },
     error: new Error('big error')
   }
 };


### PR DESCRIPTION
## Need

```
As a developer
I would love to serialize my data
So that I can put it in a file
```

## Deliverables
Data that can be serialized (without circular reference).

## Solution

Excluding the `Mocha test obj`, because it has circular reference, i.e cannot be "stringified". We will put each prop "by hande":

```js
var test = {
  x: mochaTest.x,
  y: myprop
}
```

For testing we should test each property, this way the tests shouldn't be affected by adding other props to our `Test` object. And maybe some refactoring to the other tests to test only one thing of the `Test obj` and not the whole obj.