### PR TITLE
Data generation exports test duration

### DIFF
--- a/lib/data-generator.js
+++ b/lib/data-generator.js
@@ -22,7 +22,8 @@ module.exports = function(runner, done) {
       title: test.title,
       state: test.state,
       result: test.ctx.result,
-      error: test.err
+      error: test.err,
+      duration: test.duration
     });
   });
 

--- a/test/unit/data-generator.js
+++ b/test/unit/data-generator.js
@@ -74,8 +74,8 @@ function generateTests(n, type) {
 
 describe('Data generator', function() {
   var suiteProps = ['title', 'indent', 'tests'],
-      passTestProps = ['title', 'state', 'result'],
-      failTestProps = ['title', 'state', 'result', 'error'],
+      passTestProps = ['title', 'state', 'result', 'duration'],
+      failTestProps = ['title', 'state', 'result', 'error', 'duration'],
       runner;
 
   beforeEach(function() {

--- a/test/unit/data/input.js
+++ b/test/unit/data/input.js
@@ -12,7 +12,8 @@ module.exports = {
       result: {
         isEqual: true
       }
-    }
+    },
+    duration: 7
   },
   failTest: {
     title: 'test',
@@ -22,6 +23,7 @@ module.exports = {
         isEqual: false
       }
     },
-    err: new Error('big error')
+    err: new Error('big error'),
+    duration: 1.5
   }
 };

--- a/test/unit/data/output.js
+++ b/test/unit/data/output.js
@@ -14,7 +14,8 @@ module.exports = {
     state: 'passed',
     result: {
       isEqual: true
-    }
+    },
+    duration: 7
   },
   failTest: {
     title: 'test',
@@ -22,6 +23,7 @@ module.exports = {
     result: {
       isEqual: false
     },
-    error: new Error('big error')
+    error: new Error('big error'),
+    duration: 1.5
   }
 };


### PR DESCRIPTION
## Need

```gherkin
As a user
I want to know my tests duration
So that I know if there is need for improvements
```

## Deliverables

More details about tests.


## Solution

On the [test end](https://github.com/uberVU/mocha-mugshot-reporter/blob/d8df2bcc9ff1053bf75e9595e561b30194c85bd8/lib/data-generator.js#L20) event to add another prop, i.e `duration`.